### PR TITLE
docs: document pre-commit hooks

### DIFF
--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -5,8 +5,13 @@ code style.
 
 ## Configured hooks
 
-- `trailing-whitespace` and `end-of-file-fixer` from `pre-commit-hooks`
-- `yamllint` enforcing a maximum line length of 79 characters
+- `trailing-whitespace`
+- `end-of-file-fixer`
+- `mixed-line-ending` (fixes line endings to LF)
+- `check-yaml`
+- `check-added-large-files`
+- `yamllint` enforcing a maximum YAML line length of 140 characters as configured in `.yamllint.yml`
+- `black` enforcing a maximum Python line length of 79 characters
 - `flake8` enforcing a maximum Python line length of 79 characters
 
 Run all checks locally with:


### PR DESCRIPTION
## Summary
- list all pre-commit hooks in docs/pre-commit.md
- mention YAML line-length limit from .yamllint.yml

## Testing
- `poetry run pre-commit run --files docs/pre-commit.md` *(fails: Command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2decfc48321b53e7aeae44dcfd6