### PR TITLE
chore: add hass config check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,11 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+  - repo: local
+    hooks:
+      - id: hass-config-check
+        name: hass config check
+        entry: poetry run hass --script check_config
+        language: system
+        pass_filenames: false
+        files: ^configuration\.yaml$

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -13,6 +13,7 @@ code style.
 - `yamllint` enforcing a maximum YAML line length of 140 characters as configured in `.yamllint.yml`
 - `black` enforcing a maximum Python line length of 79 characters
 - `flake8` enforcing a maximum Python line length of 79 characters
+- `hass-config-check` validates the Home Assistant configuration
 
 Run all checks locally with:
 


### PR DESCRIPTION
## Summary
- add local pre-commit hook to run `hass --script check_config`
- document Home Assistant config check pre-commit hook

## Testing
- `poetry run pre-commit run --all-files` *(fails: fatal unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb57fcc08321a01fe14d5227795a