### PR TITLE
feat(dashboard): add core Network dashboard (Overview + Details)

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -2,163 +2,245 @@
   alias: Humidor Plug – Temperature Control
   description: Turn ON humidor plug when temp > 74°F; turn OFF when temp < 68°F.
   trigger:
-    - platform: numeric_state
-      entity_id: sensor.hygrometer_humidor_temperature
-      above: 74
-    - platform: numeric_state
-      entity_id: sensor.hygrometer_humidor_temperature
-      below: 68
+  - platform: numeric_state
+    entity_id: sensor.hygrometer_humidor_temperature
+    above: 74
+  - platform: numeric_state
+    entity_id: sensor.hygrometer_humidor_temperature
+    below: 68
   condition: []
   action:
-    - choose:
-        - conditions:
-            - condition: numeric_state
-              entity_id: sensor.hygrometer_humidor_temperature
-              above: 74
-          sequence:
-            - condition: state
-              entity_id: switch.plug_humidor
-              state: "off"
-            - service: switch.turn_on
-              target:
-                entity_id: switch.plug_humidor
-        - conditions:
-            - condition: numeric_state
-              entity_id: sensor.hygrometer_humidor_temperature
-              below: 68
-          sequence:
-            - condition: state
-              entity_id: switch.plug_humidor
-              state: "on"
-            - service: switch.turn_off
-              target:
-                entity_id: switch.plug_humidor
+  - choose:
+    - conditions:
+      - condition: numeric_state
+        entity_id: sensor.hygrometer_humidor_temperature
+        above: 74
+      sequence:
+      - condition: state
+        entity_id: switch.plug_humidor
+        state: 'off'
+      - service: switch.turn_on
+        target:
+          entity_id: switch.plug_humidor
+    - conditions:
+      - condition: numeric_state
+        entity_id: sensor.hygrometer_humidor_temperature
+        below: 68
+      sequence:
+      - condition: state
+        entity_id: switch.plug_humidor
+        state: 'on'
+      - service: switch.turn_off
+        target:
+          entity_id: switch.plug_humidor
   mode: single
-
 - id: outdoor_lights_control
   alias: Outdoor Lights Control - Sunrise/Sunset
   trigger:
-    - platform: sun
-      event: sunrise
-      id: sunrise
-    - platform: sun
-      event: sunset
-      id: sunset
+  - platform: sun
+    event: sunrise
+    id: sunrise
+  - platform: sun
+    event: sunset
+    id: sunset
   condition: []
   action:
-    - choose:
-        - conditions:
-            - condition: trigger
-              id: sunrise
-          sequence:
-            - service: light.turn_off
-              target:
-                entity_id:
-                  - light.permanent_outdoor_lights
-                  - light.garage_left
-                  - light.garage_right
-                  - light.garage_center
-                  - light.front_porch_lights
-        - conditions:
-            - condition: trigger
-              id: sunset
-          sequence:
-            - service: light.turn_on
-              target:
-                entity_id: light.permanent_outdoor_lights
-              data:
-                brightness_pct: 50
-            - service: light.turn_on
-              target:
-                entity_id:
-                  - light.garage_left
-                  - light.garage_right
-                  - light.garage_center
-                  - light.front_porch_lights
-              data:
-                brightness_pct: 1
+  - choose:
+    - conditions:
+      - condition: trigger
+        id: sunrise
+      sequence:
+      - service: light.turn_off
+        target:
+          entity_id:
+          - light.permanent_outdoor_lights
+          - light.garage_left
+          - light.garage_right
+          - light.garage_center
+          - light.front_porch_lights
+    - conditions:
+      - condition: trigger
+        id: sunset
+      sequence:
+      - service: light.turn_on
+        target:
+          entity_id: light.permanent_outdoor_lights
+        data:
+          brightness_pct: 50
+      - service: light.turn_on
+        target:
+          entity_id:
+          - light.garage_left
+          - light.garage_right
+          - light.garage_center
+          - light.front_porch_lights
+        data:
+          brightness_pct: 1
   mode: single
-
 - id: early_morning_lights
   alias: 3:30 AM Light Activation
-  trigger:
-    - platform: time
-      at: "03:30:00"
-  condition: []
-  action:
-    - parallel:
-        - sequence:
-            - service: light.turn_on
-              target:
-                entity_id: light.permanent_outdoor_lights
-            - service: light.turn_on
-              target:
-                entity_id:
-                  - light.garage_left
-                  - light.garage_right
-                  - light.garage_center
-                  - light.front_porch_lights
-              data:
-                transition: 3
-                brightness_pct: 1
-        - service: light.turn_on
-          target:
-            entity_id:
-              - light.sunroom_light
-              - light.diningroom_light
-              - light.livingroom_light
-          data:
-            brightness_pct: 10
+  triggers:
+  - at: 03:30:00
+    trigger: time
+  conditions: []
+  actions:
+  - parallel:
+    - sequence:
+      - target:
+          entity_id: light.permanent_outdoor_lights
+        action: light.turn_on
+        data: {}
+      - target:
+          entity_id:
+          - light.garage_left
+          - light.garage_right
+          - light.garage_center
+          - light.front_porch_lights
+        data:
+          transition: 3
+          brightness_pct: 10
+        action: light.turn_on
+    - sequence:
+      - target:
+          entity_id:
+          - light.sunroom_light
+          - light.diningroom_light
+          - light.livingroom_light
+        data:
+          brightness_pct: 10
+        action: light.turn_on
   mode: single
-
 - id: exterior_led_monthly_effect
   alias: Exterior LED - Monthly Effect
   mode: single
   trigger:
-    - platform: time
-      at: "00:00:00"
+  - platform: time
+    at: 00:00:00
   variables:
-    current_month: "{{ now().month }}"
-    # Map each month to a Govee effect name on H705A
+    current_month: '{{ now().month }}'
     monthly_effects:
-      1: "LED-January"
-      2: "LED-February"
-      3: "LED-March"
-      4: "LED-April"
-      5: "BSMT-Patriotic" # May
-      6: "BSMT-Patriotic" # June
-      7: "BSMT-Patriotic" # July
-      8: "LED-August" # August
-      9: "LED-August" # September
-      10: "Halloween"
-      11: "LED-Thanksgiving"
-      12: "Christmas"
+      1: LED-January
+      2: LED-February
+      3: LED-March
+      4: LED-April
+      5: BSMT-Patriotic
+      6: BSMT-Patriotic
+      7: BSMT-Patriotic
+      8: LED-August
+      9: LED-August
+      10: Halloween
+      11: LED-Thanksgiving
+      12: Christmas
   condition: []
   action:
-    - variables:
-        target_effect: "{{ monthly_effects[current_month] }}"
-    # (Optional safety) Only run if the effect actually exists on the device
-    - condition: template
-      value_template: >
-        {{ target_effect in (state_attr('light.permanent', 'effect_list') or []) }}
-    - service: light.turn_on
-      target:
-        entity_id: light.permanent_outdoor_lights
-      data:
-        effect: "{{ target_effect }}"
+  - variables:
+      target_effect: '{{ monthly_effects[current_month] }}'
+  - condition: template
+    value_template: '{{ target_effect in (state_attr(''light.permanent_outdoor_lights'',
+      ''effect_list'') or []) }}
 
+      '
+  - service: light.turn_on
+    target:
+      entity_id: light.permanent_outdoor_lights
+    data:
+      effect: '{{ target_effect }}'
 - id: interior_lights_sunrise_off
   alias: Interior Lights Off - 15 Minutes After Sunrise
   trigger:
-    - platform: sun
-      event: sunrise
-      offset: "00:15:00"
+  - platform: sun
+    event: sunrise
+    offset: 00:15:00
   condition: []
   action:
-    - service: light.turn_off
-      target:
-        entity_id:
-          - light.sunroom_light
-          - light.livingroom_light
-          - light.diningroom_light
+  - service: light.turn_off
+    target:
+      entity_id:
+      - light.sunroom_light
+      - light.livingroom_light
+      - light.diningroom_light
+  mode: single
+- id: lights_off_except_porch_garage_attic_2330
+  alias: Lights Off Except Porch/Garage/Attic @ 23:30
+  description: 'At 11:30 PM, turn OFF all lights except the front porch, garage, and
+    attic.
+
+    '
+  trigger:
+  - platform: time
+    at: '23:30:00'
+  condition: []
+  action:
+  - variables:
+      exceptions:
+      - light.front_porch_lights
+      - light.front_porch
+      - light.garage_lights
+      - light.garage
+      - light.attic_light
+      - light.attic
+      turn_off_list: "{{ states.light\n   | rejectattr('entity_id','in', exceptions)\n
+        \  | selectattr('state','eq','on')\n   | map(attribute='entity_id') | list
+        }}\n"
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: '{{ turn_off_list | length > 0 }}'
+      sequence:
+      - service: light.turn_off
+        target:
+          entity_id: '{{ turn_off_list }}'
+  mode: single
+- id: '1755305405794'
+  alias: Midnight lights
+  description: ''
+  triggers:
+  - trigger: time
+    at: 00:00:00
+  conditions: []
+  actions:
+  - action: light.turn_off
+    metadata: {}
+    data: {}
+    target:
+      entity_id:
+      - light.front_porch_lights
+      - light.garage_lights
+  - type: turn_on
+    device_id: 59ce59873a8a6b7c7b48b4d311af8606
+    entity_id: 8a639fe5a1dfb86cffaafdd92550355b
+    domain: light
+    brightness_pct: 20
+  mode: single
+- id: '1755305842459'
+  alias: Bedroom-purifier on
+  description: ''
+  triggers:
+  - type: turned_on
+    device_id: f4d2eb3ede17ec2db2485c5f094bf6ad
+    entity_id: 73dbec16d31025a64677606382fa35aa
+    domain: switch
+    trigger: device
+  conditions: []
+  actions:
+  - type: turn_off
+    device_id: 6e3a0d96120bc4222780d4f255f88414
+    entity_id: a0ac47bc0794f26c2cce245f4e4200d3
+    domain: switch
+  mode: single
+- id: '1755305876272'
+  alias: Bedroom-purifier-off
+  description: ''
+  triggers:
+  - type: changed_states
+    device_id: f4d2eb3ede17ec2db2485c5f094bf6ad
+    entity_id: 73dbec16d31025a64677606382fa35aa
+    domain: switch
+    trigger: device
+  conditions: []
+  actions:
+  - type: turn_on
+    device_id: 6e3a0d96120bc4222780d4f255f88414
+    entity_id: a0ac47bc0794f26c2cce245f4e4200d3
+    domain: switch
   mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -12,3 +12,5 @@ scene: !include scenes.yaml
 group: !include group.yaml
 light: !include light.yaml
 sensor: !include sensor.yaml
+template: !include templates.yaml
+binary_sensor: !include binary_sensors.yaml

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -61,24 +61,35 @@
             ) | round(3) }}
         threshold_hpa: "3.0"
 
-# ---- Storm watch if pressure drop > ~3 hPa in 24h ----
-- platform: template
-  sensors:
-    kneplatt72_storm_watch:
-      friendly_name: "KNEPLATT72 Storm Watch"
-      value_template: >-
-        {% set u = state_attr('sensor.kneplatt72_pressure','unit_of_measurement') or '' %}
-        {% set d = states('sensor.kneplatt72_pressure_24h_change')|float(0) %}
-        {% set delta_hpa = d if u in ['hPa','mbar'] else (d * 33.8638866667) %}
-        {{ delta_hpa < -3.0 }}
-      icon_template: >-
-        {% if is_state('sensor.kneplatt72_storm_watch','True') %}mdi:weather-cloudy-alert
-        {% else %}mdi:weather-sunny
-        {% endif %}
-      attribute_templates:
-        delta_hpa: >-
-          {{ (
-              states('sensor.kneplatt72_pressure_24h_change')|float(0) *
-              (33.8638866667 if (state_attr('sensor.kneplatt72_pressure','unit_of_measurement') not in ['hPa','mbar']) else 1)
-            ) | round(2) }}
-        threshold_hpa: "3.0"
+# ---- 24h statistics based on KNEPLATT72 sensors ----
+- platform: statistics
+  name: KNEPLATT72 Wind Speed (24h Avg)
+  unique_id: kneplatt72_wind_speed_24h_avg
+  entity_id: sensor.kneplatt72_wind_speed
+  state_characteristic: mean
+  max_age:
+    hours: 24
+
+- platform: statistics
+  name: KNEPLATT72 Temperature (24h Mean)
+  unique_id: kneplatt72_temperature_24h_mean
+  entity_id: sensor.kneplatt72_temperature
+  state_characteristic: mean
+  max_age:
+    hours: 24
+
+- platform: statistics
+  name: KNEPLATT72 Humidity (24h Mean)
+  unique_id: kneplatt72_humidity_24h_mean
+  entity_id: sensor.kneplatt72_relative_humidity
+  state_characteristic: mean
+  max_age:
+    hours: 24
+
+- platform: statistics
+  name: KNEPLATT72 Pressure (24h Change)
+  unique_id: kneplatt72_pressure_24h_change
+  entity_id: sensor.kneplatt72_pressure
+  state_characteristic: change
+  max_age:
+    hours: 24

--- a/templates.yaml
+++ b/templates.yaml
@@ -1,0 +1,82 @@
+- sensor:
+    # ---- Pressure trend (rising / steady / falling) ----
+    - name: KNEPLATT72 Pressure Trend
+      unique_id: kneplatt72_pressure_trend
+      state: >-
+        {% set u = state_attr('sensor.kneplatt72_pressure','unit_of_measurement') or '' %}
+        {% set d = states('sensor.kneplatt72_pressure_24h_change')|float(0) %}
+        {% set delta_hpa = d if u in ['hPa','mbar'] else (d * 33.8638866667) %}
+        {% if delta_hpa > 0.7 %}rising{% elif delta_hpa < -0.7 %}falling{% else %}steady{% endif %}
+      icon: >-
+        {% set s = this.state %}
+        {% if s == 'rising' %}mdi:arrow-up-bold
+        {% elif s == 'falling' %}mdi:arrow-down-bold
+        {% else %}mdi:arrow-right-bold
+        {% endif %}
+      attributes:
+        delta_hpa: >-
+          {{ (
+              states('sensor.kneplatt72_pressure_24h_change')|float(0) *
+              (33.8638866667 if (state_attr('sensor.kneplatt72_pressure','unit_of_measurement') not in ['hPa','mbar']) else 1)
+            ) | round(2) }}
+        delta_inhg: >-
+          {{ (
+              (states('sensor.kneplatt72_pressure_24h_change')|float(0) / 33.8638866667)
+              if (state_attr('sensor.kneplatt72_pressure','unit_of_measurement') in ['hPa','mbar'])
+              else states('sensor.kneplatt72_pressure_24h_change')|float(0)
+            ) | round(3) }}
+        threshold_hpa: "3.0"
+
+    # ---- Nmap metrics ----
+    - name: Nmap Active Hosts
+      unique_id: nmap_active_hosts
+      state: >-
+        {% set nmap = integration_entities('nmap_tracker') %}
+        {{ expand(nmap)
+            | selectattr('domain', 'equalto', 'device_tracker')
+            | selectattr('state', 'equalto', 'home')
+            | list | length }}
+      icon: mdi:lan
+
+    - name: Nmap Known Hosts
+      unique_id: nmap_known_hosts
+      state: >-
+        {% set nmap = integration_entities('nmap_tracker') %}
+        {{ expand(nmap)
+            | selectattr('domain', 'equalto', 'device_tracker')
+            | list | length }}
+      icon: mdi:lan-check
+
+    - name: Internet Status
+      state: >-
+        {% if is_state('binary_sensor.internet_reachable','on') %}
+          Online ({{ states('sensor.internet_latency') }} ms)
+        {% else %}
+          Offline
+        {% endif %}
+
+    - name: TP-Link Clients Online
+      unique_id: tplink_clients_online
+      state: >-
+        {% set tpl = integration_entities('tplink_router') %}
+        {{ expand(tpl)
+           | selectattr('domain','equalto','device_tracker')
+           | selectattr('state','equalto','home')
+           | list | length }}
+      icon: mdi:wifi
+
+    # ---- Internet status (uses Ping integration entities) ----
+    - name: Internet Status
+      unique_id: internet_status
+      state: >-
+        {% if is_state('binary_sensor.internet_reachable','on') %}
+          Online ({{ states('sensor.internet_reachable_latency') }} ms)
+        {% else %}
+          Offline
+        {% endif %}
+      icon: >-
+        {% if is_state('binary_sensor.internet_reachable','on') %}
+          mdi:check-network
+        {% else %}
+          mdi:close-network
+        {% endif %}

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -65,3 +65,5 @@ devices:
     friendly_name: Plug-Mainfloor-burner
   '0x187a3efffec58181':
     friendly_name: Sensor-office
+  '0x282c02bfffeff7c5':
+    friendly_name: Plug-bedroom-burner


### PR DESCRIPTION
- New dashboard Network with two views: • Overview: Internet status, Speedtest gauges, latency history, Nmap active/known counts, and TP-Link client totals with quick controls. • Details: Grouped Nmap, Ping/Internet, Speedtest, and TP-Link entities with history graphs for deeper inspection.
- Uses only core Lovelace cards (glance, gauge, entities, history-graph).
- Aligns with existing template sensors (internet_status, nmap metrics).

## Summary
Explain the change and the problem it solves.

## Changes
- [ ] Config and docs updated
- [ ] Submodule bumped (if applicable)
- [ ] CI passes

## Testing
Steps to verify (commands, screenshots).

## Notes
Link issues/ADRs/related PRs.
