### PR TITLE
Streamline exterior alternating color show loop

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -260,24 +260,3 @@
         | int(0)) }}'
   action:
     - service: script.huskers_touchdown_burst
-- id: huskers_exterior_alternating_loop
-  alias: 'Huskers: Exterior Alternating Loop (Start)'
-  mode: restart
-  trigger:
-    - platform: state
-      entity_id: input_boolean.huskers_exterior_color_show
-      to: 'on'
-  variables:
-    delay_seconds: 20
-  condition: []
-  action:
-    - repeat:
-        while:
-          - condition: state
-            entity_id: input_boolean.huskers_exterior_color_show
-            state: 'on'
-        sequence:
-          - service: script.huskers_exterior_alternating_start
-          - delay: '{{ delay_seconds }}'
-          - service: script.huskers_exterior_alternating_inverted_start
-          - delay: '{{ delay_seconds }}'

--- a/lovelace/views/30_controls.yaml
+++ b/lovelace/views/30_controls.yaml
@@ -62,12 +62,12 @@
             target: { entity_id: script.huskers_exterior_alternating_start }
 
         - type: button
-          name: Alternating Inverted (Exterior)
-          icon: mdi:palette-swatch-outline
+          name: Alternating (Exterior) – Stop
+          icon: mdi:stop
           tap_action:
             action: call-service
             service: script.turn_on
-            target: { entity_id: script.huskers_exterior_alternating_inverted_start }
+            target: { entity_id: script.huskers_exterior_alternating_stop }
 
     # Theater controls
     - type: markdown

--- a/scripts.yaml
+++ b/scripts.yaml
@@ -431,55 +431,9 @@ huskers_exterior_alternating_start:
               predim_pct: 10
               predim_hold: 1
           - delay: 5
-huskers_exterior_alternating_inverted_start:
-  alias: "Huskers: Exterior Alternating (Inverted) \u2013 Start (2-step fade)"
-  mode: single
-  sequence:
-    - service: script.util_fade_color
-      data:
-        light: light.light_front_left
-        h: 48
-        s: 12
-        brightness: 255
-        transition: 5
-        predim_pct: 10
-        predim_hold: 1
-    - service: script.util_fade_color
-      data:
-        light: light.light_front_right
-        h: 355
-        s: 90
-        brightness: 255
-        transition: 5
-        predim_pct: 10
-        predim_hold: 1
-    - service: script.util_fade_color
-      data:
-        light: light.garage_l
-        h: 48
-        s: 12
-        brightness: 255
-        transition: 5
-        predim_pct: 10
-        predim_hold: 1
-    - service: script.util_fade_color
-      data:
-        light: light.garage_c
-        h: 355
-        s: 90
-        brightness: 255
-        transition: 5
-        predim_pct: 10
-        predim_hold: 1
-    - service: script.util_fade_color
-      data:
-        light: light.garage_r
-        h: 48
-        s: 12
-        brightness: 255
-        transition: 5
-        predim_pct: 10
-        predim_hold: 1
+    - service: input_boolean.turn_off
+      target:
+        entity_id: input_boolean.huskers_exterior_color_show
 huskers_theater_scarlet_fade:
   alias: 'Huskers: Theater Scarlet Fade'
   mode: single


### PR DESCRIPTION
## Summary
- drop huskers_exterior_alternating_loop automation
- fold alternating/inverted steps into huskers_exterior_alternating_start and handle boolean cleanup
- expose start/stop buttons for exterior alternating show

## Testing
- `pre-commit run --files automations.yaml scripts.yaml lovelace/views/30_controls.yaml` *(fails: unable to access https://github.com/pre-commit/mirrors-prettier/)*

------
https://chatgpt.com/codex/tasks/task_e_68ab529497e08321915ab219f0d56af7