### PR TITLE
chore: resolve yamllint warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on:
+'on':
   push:
     branches:
       - main

--- a/scenes.yaml
+++ b/scenes.yaml
@@ -54,23 +54,28 @@
     light.light_front_left:
       state: 'on'
       brightness: 255
-      hs_color: [355, 90] # Scarlet
+      # prettier-ignore
+      hs_color: [355, 90]  # Scarlet
     light.light_front_right:
       state: 'on'
       brightness: 255
-      hs_color: [48, 12] # Cream
+      # prettier-ignore
+      hs_color: [48, 12]  # Cream
     light.garage_l:
       state: 'on'
       brightness: 255
-      hs_color: [355, 90] # Scarlet
+      # prettier-ignore
+      hs_color: [355, 90]  # Scarlet
     light.garage_c:
       state: 'on'
       brightness: 255
-      hs_color: [48, 12] # Cream
+      # prettier-ignore
+      hs_color: [48, 12]  # Cream
     light.garage_r:
       state: 'on'
       brightness: 255
-      hs_color: [355, 90] # Scarlet
+      # prettier-ignore
+      hs_color: [355, 90]  # Scarlet
 
 # PURPOSE: Inverted pattern (start with CREAM on FRONT LEFT).
 # PATTERN: Cream (front left), Scarlet (front right), Cream (garage L),
@@ -82,20 +87,25 @@
     light.light_front_left:
       state: 'on'
       brightness: 255
-      hs_color: [48, 12] # Cream
+      # prettier-ignore
+      hs_color: [48, 12]  # Cream
     light.light_front_right:
       state: 'on'
       brightness: 255
-      hs_color: [355, 90] # Scarlet
+      # prettier-ignore
+      hs_color: [355, 90]  # Scarlet
     light.garage_l:
       state: 'on'
       brightness: 255
-      hs_color: [48, 12] # Cream
+      # prettier-ignore
+      hs_color: [48, 12]  # Cream
     light.garage_c:
       state: 'on'
       brightness: 255
-      hs_color: [355, 90] # Scarlet
+      # prettier-ignore
+      hs_color: [355, 90]  # Scarlet
     light.garage_r:
       state: 'on'
       brightness: 255
-      hs_color: [48, 12] # Cream
+      # prettier-ignore
+      hs_color: [48, 12]  # Cream

--- a/templates.yaml
+++ b/templates.yaml
@@ -39,7 +39,8 @@
           {% else %}
             {{ d | round(3) }}
           {% endif %}
-        threshold_hpa: 0.7 # trend threshold (not storm threshold)
+          # prettier-ignore
+          threshold_hpa: 0.7  # trend threshold (not storm threshold)
 
     # ---- Nmap metrics ----
     - name: 'Nmap Active Hosts'


### PR DESCRIPTION
## Summary
- fix inline comment spacing in templates and scenes
- quote `on` key in CI workflow to satisfy yamllint

## Testing
- `yamllint -s .`
- `pre-commit run --all-files --show-diff-on-failure` *(fails: unable to access https://github.com/pre-commit/mirrors-prettier/)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aioblescan')*


------
https://chatgpt.com/codex/tasks/task_e_68ab86f8b1988321b939745731db971c