### PR TITLE
feat: add fan zone dashboard

### DIFF
--- a/lovelace/README.md
+++ b/lovelace/README.md
@@ -30,6 +30,9 @@ This document explains the refactor of the Huskers Lovelace dashboard to follow 
 6. **Notes:**
    - Lint errors about missing entities/scripts are warnings that those entities must exist in your Home Assistant instance for the dashboard to function fully.
    - No changes were made to the logic or appearance of the dashboard—only the structure was improved.
+7. **Added Fan Zone View:**
+   - `views/50_fan_zone.yaml` introduces a playful Huskers dashboard with score gauges and quick lighting controls.
+   - For UI-managed dashboards, copy the snippet from `../ui-lovelace/views/40_fan_zone.yaml` via the Raw configuration editor.
 
 ## Directory Structure Example
 

--- a/lovelace/views/50_fan_zone.yaml
+++ b/lovelace/views/50_fan_zone.yaml
@@ -1,0 +1,68 @@
+# Huskers – Fan Zone
+- title: Huskers – Fan Zone
+  path: huskers-fan-zone
+  icon: mdi:stadium-variant
+  badges: []
+  cards:
+    - type: markdown
+      content: |
+        # Go Big Red!
+        Welcome to the **Huskers Fan Zone**. Cheer on Nebraska and control game-day lighting.
+    - type: picture
+      image: /local/huskers_logo.svg
+      tap_action:
+        action: none
+    - type: grid
+      columns: 2
+      square: false
+      cards:
+        - type: gauge
+          entity: sensor.huskers_our_score
+          min: 0
+          max: 100
+          name: Nebraska
+        - type: gauge
+          entity: sensor.huskers_opponent_score
+          min: 0
+          max: 100
+          name: Opponent
+    - type: entities
+      title: Game Info
+      state_color: true
+      entities:
+        - entity: sensor.huskers_game_status
+          name: Status
+        - entity: sensor.huskers_quarter
+          name: Quarter
+        - entity: sensor.huskers_game_clock
+          name: Clock
+        - entity: sensor.huskers_next_game_start
+          name: Next Game
+    - type: grid
+      columns: 3
+      square: false
+      cards:
+        - type: button
+          name: Start Show
+          icon: mdi:play
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_theater_show_start
+        - type: button
+          name: Touchdown Burst
+          icon: mdi:firework
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_touchdown_burst
+        - type: button
+          name: Stop Show
+          icon: mdi:stop
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_theater_show_stop

--- a/ui-lovelace/README.md
+++ b/ui-lovelace/README.md
@@ -1,0 +1,84 @@
+# UI Lovelace Dashboard
+
+This directory contains a copy-and-paste friendly view for Home Assistant dashboards managed through the UI.
+
+## Huskers Fan Zone View
+
+To add the Huskers Fan Zone to a UI dashboard:
+
+1. Place `www/huskers_logo.svg` in your Home Assistant `config/www` folder.
+2. In Home Assistant, open your dashboard, choose **Edit Dashboard**, then select **Raw configuration editor**.
+3. Append the following snippet under your `views:` list or use it as the entire dashboard configuration:
+
+```yaml
+views:
+  - title: Huskers – Fan Zone
+    path: huskers-fan-zone
+    icon: mdi:stadium-variant
+    badges: []
+    cards:
+      - type: markdown
+        content: |
+          # Go Big Red!
+          Welcome to the **Huskers Fan Zone**. Cheer on Nebraska and control game-day lighting.
+      - type: picture
+        image: /local/huskers_logo.svg
+        tap_action:
+          action: none
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: gauge
+            entity: sensor.huskers_our_score
+            min: 0
+            max: 100
+            name: Nebraska
+          - type: gauge
+            entity: sensor.huskers_opponent_score
+            min: 0
+            max: 100
+            name: Opponent
+      - type: entities
+        title: Game Info
+        state_color: true
+        entities:
+          - entity: sensor.huskers_game_status
+            name: Status
+          - entity: sensor.huskers_quarter
+            name: Quarter
+          - entity: sensor.huskers_game_clock
+            name: Clock
+          - entity: sensor.huskers_next_game_start
+            name: Next Game
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - type: button
+            name: Start Show
+            icon: mdi:play
+            tap_action:
+              action: call-service
+              service: script.turn_on
+              target:
+                entity_id: script.huskers_theater_show_start
+          - type: button
+            name: Touchdown Burst
+            icon: mdi:firework
+            tap_action:
+              action: call-service
+              service: script.turn_on
+              target:
+                entity_id: script.huskers_touchdown_burst
+          - type: button
+            name: Stop Show
+            icon: mdi:stop
+            tap_action:
+              action: call-service
+              service: script.turn_on
+              target:
+                entity_id: script.huskers_theater_show_stop
+```
+
+The snippet above mirrors the contents of `views/40_fan_zone.yaml`, making it easy to import into a UI-managed dashboard.

--- a/ui-lovelace/views/40_fan_zone.yaml
+++ b/ui-lovelace/views/40_fan_zone.yaml
@@ -1,0 +1,68 @@
+# Huskers – Fan Zone
+- title: Huskers – Fan Zone
+  path: huskers-fan-zone
+  icon: mdi:stadium-variant
+  badges: []
+  cards:
+    - type: markdown
+      content: |
+        # Go Big Red!
+        Welcome to the **Huskers Fan Zone**. Cheer on Nebraska and control game-day lighting.
+    - type: picture
+      image: /local/huskers_logo.svg
+      tap_action:
+        action: none
+    - type: grid
+      columns: 2
+      square: false
+      cards:
+        - type: gauge
+          entity: sensor.huskers_our_score
+          min: 0
+          max: 100
+          name: Nebraska
+        - type: gauge
+          entity: sensor.huskers_opponent_score
+          min: 0
+          max: 100
+          name: Opponent
+    - type: entities
+      title: Game Info
+      state_color: true
+      entities:
+        - entity: sensor.huskers_game_status
+          name: Status
+        - entity: sensor.huskers_quarter
+          name: Quarter
+        - entity: sensor.huskers_game_clock
+          name: Clock
+        - entity: sensor.huskers_next_game_start
+          name: Next Game
+    - type: grid
+      columns: 3
+      square: false
+      cards:
+        - type: button
+          name: Start Show
+          icon: mdi:play
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_theater_show_start
+        - type: button
+          name: Touchdown Burst
+          icon: mdi:firework
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_touchdown_burst
+        - type: button
+          name: Stop Show
+          icon: mdi:stop
+          tap_action:
+            action: call-service
+            service: script.turn_on
+            target:
+              entity_id: script.huskers_theater_show_stop

--- a/www/huskers_logo.svg
+++ b/www/huskers_logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#D00000"/>
+  <text x="50" y="70" font-size="80" font-family="Arial" font-weight="bold" fill="#FFFFFF" text-anchor="middle">N</text>
+</svg>


### PR DESCRIPTION
## Summary
- add local Huskers logo and reference it from fan zone view
- provide fan zone view in `ui-lovelace` for easy drop-in
- document how to copy/paste the fan zone view into a UI-managed dashboard

## Testing
- `yamllint ui-lovelace/views/40_fan_zone.yaml`
- `pre-commit run --files lovelace/README.md ui-lovelace/README.md ui-lovelace/views/40_fan_zone.yaml` *(fails: CONNECT tunnel failed, response 403)*
- `hass --script check_config --config .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1832f3648321bf6d727295677b13