### PR TITLE
Make network dashboard tiles configurable

### DIFF
--- a/dashboards/network.dashboard.yaml
+++ b/dashboards/network.dashboard.yaml
@@ -117,7 +117,7 @@ views:
         square: false
         cards:
           - type: tile
-            entity: binary_sensor.internet_reachability
+            entity: binary_sensor.network_dashboard_internet_online
             name: Internet online
             color: '#43a047'
           - type: tile
@@ -129,7 +129,7 @@ views:
             name: Deco health
             color: '#1e88e5'
           - type: tile
-            entity: sensor.internet_latency
+            entity: sensor.network_dashboard_live_latency
             name: Live latency
             color: '#039be5'
           - type: tile

--- a/input_text.yaml
+++ b/input_text.yaml
@@ -9,3 +9,15 @@ weather_station_label:
   icon: mdi:sign-text
   initial: !secret weather_station_label
   mode: text
+
+network_dashboard_internet_online_source:
+  name: Network Dashboard Internet Online Source
+  icon: mdi:lan-check
+  initial: ''
+  mode: text
+
+network_dashboard_latency_source:
+  name: Network Dashboard Latency Source
+  icon: mdi:speedometer
+  initial: ''
+  mode: text

--- a/packages/network_monitor.yaml
+++ b/packages/network_monitor.yaml
@@ -107,6 +107,93 @@ template:
                 unavailable
               {% endif %}
             {% endif %}
+      - name: Network Dashboard Internet Online
+        unique_id: network_dashboard_internet_online
+        device_class: connectivity
+        icon: mdi:lan-check
+        variables:
+          internet_source: >-
+            {% set override = states('input_text.network_dashboard_internet_online_source') %}
+            {% set options = [
+              override,
+              'binary_sensor.internet_reachability',
+              'binary_sensor.internet_online',
+              'binary_sensor.internet_connection',
+              'binary_sensor.network_online',
+              'binary_sensor.network_connection'
+            ] %}
+            {% for candidate in options %}
+              {% if candidate not in ['', 'unknown', 'unavailable', None] %}
+                {% set value = states(candidate) %}
+                {% if value not in ['unknown', 'unavailable', None, ''] %}
+                  {{ candidate }}
+                  {% break %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          internet_state: >-
+            {% if internet_source %}
+              {{ states(internet_source) }}
+            {% else %}
+              unknown
+            {% endif %}
+        state: >-
+          {% set raw = internet_state | string | lower %}
+          {% if raw in ['on', 'true', 'online', 'connected', 'up', 'available', 'reachable', '1', 'open'] %}
+            on
+          {% elif raw in ['off', 'false', 'offline', 'disconnected', 'down', 'unreachable', 'not reachable', '0', 'closed'] %}
+            off
+          {% elif raw in ['unavailable'] %}
+            unavailable
+          {% else %}
+            unknown
+          {% endif %}
+        attributes:
+          source_entity: "{{ internet_source if internet_source else 'unknown' }}"
+          source_state: "{{ internet_state }}"
+      - name: Network Dashboard Live Latency
+        unique_id: network_dashboard_live_latency
+        unit_of_measurement: ms
+        device_class: duration
+        state_class: measurement
+        icon: mdi:speedometer
+        variables:
+          latency_source: >-
+            {% set override = states('input_text.network_dashboard_latency_source') %}
+            {% set options = [
+              override,
+              'sensor.internet_latency',
+              'sensor.internet_latency_1h_avg',
+              'sensor.internet_latency_baseline',
+              'sensor.speedtest_ping'
+            ] %}
+            {% for candidate in options %}
+              {% if candidate not in ['', 'unknown', 'unavailable', None] %}
+                {% set value = states(candidate) %}
+                {% if value not in ['unknown', 'unavailable', None, ''] %}
+                  {{ candidate }}
+                  {% break %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          latency_state: >-
+            {% if latency_source %}
+              {{ states(latency_source) }}
+            {% else %}
+              unknown
+            {% endif %}
+        state: >-
+          {% set text = latency_state | string | trim %}
+          {% if text in ['unknown', 'unavailable', ''] or latency_state is none %}
+            unknown
+          {% elif text is match('^-?[0-9]+(\.[0-9]+)?$') %}
+            {{ text | float | round(1) }}
+          {% else %}
+            unknown
+          {% endif %}
+        attributes:
+          source_entity: "{{ latency_source if latency_source else 'unknown' }}"
+          source_state: "{{ latency_state }}"
       - name: Speedtest Last Run
         unique_id: network_speedtest_last_run
         device_class: timestamp


### PR DESCRIPTION
## Summary
- add helper text inputs that allow overriding the internet status and latency sources used by the network dashboard
- expose new template sensors that normalize the selected entities and update the dashboard tiles to use them so they stay available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c35089108321850dd939580c69a7