### PR TITLE
Restore holiday guard state checks

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -10,9 +10,11 @@
         event: sunset
         offset: '00:05:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
       - condition: template
         value_template: "{{ states('binary_sensor.huskers_lighting_hold') != 'on' }}"
     action:
@@ -32,9 +34,11 @@
         event: sunset
         offset: '00:05:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
       - condition: template
         value_template: "{{ states('binary_sensor.huskers_lighting_hold') != 'on' }}"
     action:
@@ -53,9 +57,11 @@
       - platform: time
         at: '00:00:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
     action:
       - service: scene.turn_on
         target:
@@ -72,9 +78,11 @@
       - platform: time
         at: '03:30:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
     action:
       - service: scene.turn_on
         target:
@@ -92,9 +100,11 @@
         event: sunrise
         offset: '00:15:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
       - condition: state
         entity_id: binary_sensor.huskers_light_show_active
         state: 'off'
@@ -115,9 +125,11 @@
         event: sunrise
         offset: '00:05:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
       - condition: state
         entity_id: binary_sensor.huskers_light_show_active
         state: 'off'
@@ -181,9 +193,11 @@
       target_scene: '{{ target_config.get("scene") }}'
       target_effect: '{{ target_config.get("effect") }}'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
     action:
       - alias: 'Wait for permanent outdoor lights to advertise effects after startup'
         wait_template: >-
@@ -234,9 +248,11 @@
         below: 70
         for: {minutes: 1}
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
       - condition: template
         value_template: >-
           {% set temp = trigger.to_state.state | float(-999) %}
@@ -278,9 +294,11 @@
       - platform: time
         at: '23:00:00'
     condition:
-      - condition: state
-        entity_id: binary_sensor.holiday_mode_active
-        state: 'off'
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.holiday_mode_active
+            state: 'on'
     action:
       - service: scene.turn_on
         target:

--- a/docs/reference/automations.md
+++ b/docs/reference/automations.md
@@ -19,7 +19,7 @@ Use this catalog as the single source of truth for automation behaviour. Each en
 ### Lighting: Evening Lights at Sunset (`automations.yaml:3`)
 - **ID** `evening_lights_at_sunset`
 - **Trigger**: Sun sets +5 minutes (`platform: sun`, `event: sunset`, `offset: 00:05:00`).
-- **Guards**: Requires `binary_sensor.holiday_mode_active` to be `off` and `binary_sensor.huskers_lighting_hold` to be `off` so holiday overrides and Husker light shows can take priority.
+- **Guards**: Skips while `binary_sensor.holiday_mode_active` or `binary_sensor.huskers_lighting_hold` is `on` so holiday overrides and Husker light shows can take priority.
 - **Actions**: Brings sunroom, dining room, and living room lighting to 60% with a 2 s transition.
 
 ### Lighting: Exterior Front & Garage On (Sunset) (`automations.yaml:28`)
@@ -55,13 +55,13 @@ Use this catalog as the single source of truth for automation behaviour. Each en
 ### LED: Monthly Effect Scheduler (`automations.yaml:205`)
 - **ID** `exterior_led_monthly_effect`
 - **Triggers**: Time `00:00:01` daily and Home Assistant start.
-- **Guards**: Requires `binary_sensor.holiday_mode_active` to be `off` and confirms the requested `effect` exists in `light.permanent_outdoor_lights`.
+- **Guards**: Skips while `binary_sensor.holiday_mode_active` is `on` and confirms the requested `effect` exists in `light.permanent_outdoor_lights`.
 - **Actions**: Waits up to two minutes for the permanent outdoor light effect list to load after startup, applies the month-specific effect when available, and logs success or a skip if the effect never appears. See [Husker LED MQTT Controls](../how-to/lighting/husker-led-mqtt.md) for manual overrides.
 
 ### Climate: Humidor Temperature Control (`automations.yaml:251`)
 - **ID** `humidor_plug_temp_control`
 - **Triggers**: Temperature at `sensor.hygrometer_humidor_temperature` > 74°F for 2 minutes, or < 70°F for 1 minute.
-- **Guards**: Requires `binary_sensor.holiday_mode_active` to be `off` and uses a template safeguard so the plug toggles only when necessary.
+- **Guards**: Skips while `binary_sensor.holiday_mode_active` is `on` and uses a template safeguard so the plug toggles only when necessary.
 - **Actions**: Switches `switch.plug_humidor` on/off and logs temperature + humidity snapshots.
 
 ### Safety: Nightly Burner Plug Shutoff (`automations.yaml:296`)


### PR DESCRIPTION
## Summary
- replace holiday mode template guards with `condition: not` state blocks so unknown and unavailable states no longer block schedules
- refresh the automation catalog guard descriptions to match the restored holiday mode behaviour

## Testing
- poetry run yamllint automations.yaml
- poetry run pytest
- poetry run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e3a0e0efb08321a422a9ed5287241d